### PR TITLE
normalize path for SVF Downloader

### DIFF
--- a/src/svf/reader.ts
+++ b/src/svf/reader.ts
@@ -249,7 +249,7 @@ export class Reader {
         const svf = await downloadDerivative(urn, encodeURI(svfUrn)) as Buffer;
         const baseUri = svfUrn.substr(0, svfUrn.lastIndexOf('/'));
         const resolve = async (uri: string) => {
-            const buffer = await downloadDerivative(urn, encodeURI(path.join(baseUri, uri)));
+            const buffer = await downloadDerivative(urn, encodeURI(path.normalize(path.join(baseUri, uri))));
             return buffer;
         };
         return new Reader(svf, resolve);


### PR DESCRIPTION
When using the downloader via APS VS Code extension, the downloader downloads corrupt files with filenames that match `objects_*.json.gz`. From a `manifest.json` file retrieved from unzipping contents from the `.svf` file, the asset URI's for those objects include `\..\` in the path, which, when normalized, will go up the directory, and thereby download the correct contents for the file. 

I've tested this with Python and the files outputted after the normalizing the path are valid JSON and no longer corrupt. 

