### PR TITLE
Add Support for Parsing APS_REGION Environment Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ or
 ```
 export APS_CLIENT_ID=<client id>
 export APS_CLIENT_SECRET=<client secret>
+export APS_REGION=<resource region>
 svf-to-gltf <urn> --output-folder <path to output folder>
 ```
 
@@ -50,6 +51,7 @@ or
 
 ```
 export APS_ACCESS_TOKEN=<access token>
+export APS_REGION=<resource region>
 svf-to-gltf <urn> --output-folder <path to output folder>
 ```
 
@@ -64,6 +66,7 @@ or
 ```
 set APS_CLIENT_ID=<client id>
 set APS_CLIENT_SECRET=<client secret>
+set APS_REGION=<resource region>
 svf-to-gltf <urn> --output-folder <path to output folder>
 ```
 
@@ -71,6 +74,7 @@ or
 
 ```
 set APS_ACCESS_TOKEN=<access token>
+set APS_REGION=<resource region>
 svf-to-gltf <urn> --output-folder <path to output folder>
 ```
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ See [./samples/local-svf-to-gltf.sh](./samples/local-svf-to-gltf.sh) or
 - clone the repository
 - install dependencies: `yarn install`
 - build the library (transpile TypeScript): `yarn run build`
-- run samples in the _test_ subfolder, for example: `APS_CLIENT_ID=<your client id> APS_CLIENT_SECRET=<your client secret> node test/remote-svf-to-gltf.js <model urn> <path to output folder>`
+- run samples in the _test_ subfolder, for example: `APS_CLIENT_ID=<your client id> APS_CLIENT_SECRET=<your client secret> test/remote-svf-to-gltf.sh <model urn> <path to output folder>`
 
 If you're using [Visual Studio Code](https://code.visualstudio.com), you can use the following "task" and "launch" configurations:
 

--- a/samples/custom-gltf-attribute.js
+++ b/samples/custom-gltf-attribute.js
@@ -64,7 +64,7 @@ const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn, outputDir) {
     try {
-        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
+        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION);
         const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
         const writer = new CustomGltfWriter({
             deduplicate: false,

--- a/samples/custom-gltf-attribute.js
+++ b/samples/custom-gltf-attribute.js
@@ -60,11 +60,11 @@ class CustomGltfWriter extends GltfWriter {
     }
 }
 
-const { APS_CLIENT_ID, APS_CLIENT_SECRET } = process.env;
+const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn, outputDir) {
     try {
-        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET);
+        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
         const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
         const writer = new CustomGltfWriter({
             deduplicate: false,
@@ -73,7 +73,7 @@ async function run(urn, outputDir) {
             log: console.log
         });
         for (const derivative of derivatives) {
-            const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider);
+            const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider, APS_HOST, APS_REGION);
             const scene = await reader.read({ log: console.log });
             await writer.write(scene, path.join(outputDir, derivative.guid));
         }

--- a/samples/download-svf.js
+++ b/samples/download-svf.js
@@ -7,11 +7,11 @@
  */
 
 const { SvfDownloader, TwoLeggedAuthenticationProvider } = require('..');
-const { APS_CLIENT_ID, APS_CLIENT_SECRET } = process.env;
+const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn, outputDir = '.') {
     const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
-    const downloader = new SvfDownloader(authenticationProvider);
+    const downloader = new SvfDownloader(authenticationProvider, APS_HOST, APS_REGION);
     const download = downloader.download(urn, { outputDir, log: console.log });
     await download.ready;
 }

--- a/samples/filter-by-area.js
+++ b/samples/filter-by-area.js
@@ -107,7 +107,7 @@ async function run(urn, outputDir) {
     };
 
     try {
-        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
+        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION);
         const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
         const writer = new AreaFilteredGltfWriter(Object.assign({}, DefaultOptions), [-25.0, -25.0, -25.0], [25.0, 25.0, 25.0]);
         for (const derivative of derivatives) {

--- a/samples/filter-by-area.js
+++ b/samples/filter-by-area.js
@@ -96,7 +96,7 @@ class AreaFilteredGltfWriter extends GltfWriter {
     }
 }
 
-const { APS_CLIENT_ID, APS_CLIENT_SECRET } = process.env;
+const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn, outputDir) {
     const DefaultOptions = {
@@ -107,11 +107,11 @@ async function run(urn, outputDir) {
     };
 
     try {
-        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET);
+        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
         const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
         const writer = new AreaFilteredGltfWriter(Object.assign({}, DefaultOptions), [-25.0, -25.0, -25.0], [25.0, 25.0, 25.0]);
         for (const derivative of derivatives) {
-            const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider);
+            const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider, APS_HOST, APS_REGION);
             const scene = await reader.read({ log: console.log });
             await writer.write(scene, path.join(outputDir, derivative.guid));
         }

--- a/samples/remote-svf-props.js
+++ b/samples/remote-svf-props.js
@@ -9,13 +9,13 @@
 const { getSvfDerivatives } = require('./shared.js');
 const { SvfReader, TwoLeggedAuthenticationProvider } = require('..');
 
-const { APS_CLIENT_ID, APS_CLIENT_SECRET } = process.env;
+const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn) {
-    const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET);
+    const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
     const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
     for (const derivative of derivatives) {
-        const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider);
+        const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider, APS_HOST, APS_REGION);
         const propdb = await reader.getPropertyDb();
         const props = propdb.getProperties(1);
         for (const name of Object.keys(props)) {

--- a/samples/remote-svf-props.js
+++ b/samples/remote-svf-props.js
@@ -12,7 +12,7 @@ const { SvfReader, TwoLeggedAuthenticationProvider } = require('..');
 const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn) {
-    const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
+    const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION);
     const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
     for (const derivative of derivatives) {
         const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider, APS_HOST, APS_REGION);

--- a/samples/remote-svf-to-gltf.js
+++ b/samples/remote-svf-to-gltf.js
@@ -14,7 +14,7 @@ const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn, outputDir) {
     try {
-        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
+        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION);
         const writer0 = new GltfWriter({ deduplicate: false, skipUnusedUvs: false, center: true, log: console.log });
         const writer1 = new GltfWriter({ deduplicate: true, skipUnusedUvs: true, center: true, log: console.log });
         const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);

--- a/samples/remote-svf-to-gltf.js
+++ b/samples/remote-svf-to-gltf.js
@@ -10,16 +10,16 @@ const path = require('path');
 const { getSvfDerivatives } = require('./shared.js');
 const { SvfReader, GltfWriter, TwoLeggedAuthenticationProvider } = require('..');
 
-const { APS_CLIENT_ID, APS_CLIENT_SECRET } = process.env;
+const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn, outputDir) {
     try {
-        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET);
+        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
         const writer0 = new GltfWriter({ deduplicate: false, skipUnusedUvs: false, center: true, log: console.log });
         const writer1 = new GltfWriter({ deduplicate: true, skipUnusedUvs: true, center: true, log: console.log });
         const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
         for (const derivative of derivatives) {
-            const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider);
+            const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider, APS_HOST, APS_REGION);
             const scene = await reader.read({ log: console.log });
             await writer0.write(scene, path.join(outputDir, derivative.guid, 'gltf-raw'));
             await writer1.write(scene, path.join(outputDir, derivative.guid, 'gltf-dedup'));

--- a/samples/serialize-msgpack.js
+++ b/samples/serialize-msgpack.js
@@ -13,15 +13,15 @@ class MsgpackGltfWriter extends GltfWriter {
     }
 }
 
-const { APS_CLIENT_ID, APS_CLIENT_SECRET } = process.env;
+const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn, outputDir) {
     try {
-        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET);
+        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
         const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
         const writer = new MsgpackGltfWriter({ deduplicate: true, center: true, log: console.log });
         for (const derivative of derivatives) {
-            const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider);
+            const reader = await SvfReader.FromDerivativeService(urn, derivative.guid, authenticationProvider, APS_HOST, APS_REGION);
             const scene = await reader.read({ log: console.log });
             await writer.write(scene, path.join(outputDir, derivative.guid));
         }

--- a/samples/serialize-msgpack.js
+++ b/samples/serialize-msgpack.js
@@ -17,7 +17,7 @@ const { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION } = process.env;
 
 async function run(urn, outputDir) {
     try {
-        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_REGION);
+        const derivatives = await getSvfDerivatives(urn, APS_CLIENT_ID, APS_CLIENT_SECRET, APS_HOST, APS_REGION);
         const authenticationProvider = new TwoLeggedAuthenticationProvider(APS_CLIENT_ID, APS_CLIENT_SECRET);
         const writer = new MsgpackGltfWriter({ deduplicate: true, center: true, log: console.log });
         for (const derivative of derivatives) {

--- a/samples/shared.js
+++ b/samples/shared.js
@@ -13,12 +13,12 @@ async function downloadDerivative(urn, derivativeUrn, clientId, clientSecret) {
     return response.data;
 }
 
-async function getSvfDerivatives(urn, clientId, clientSecret) {
+async function getSvfDerivatives(urn, clientId, clientSecret, region) {
     const sdkManager = SdkManagerBuilder.create().build();
     const authenticationClient = new AuthenticationClient(sdkManager);
     const modelDerivativeClient = new ModelDerivativeClient(sdkManager);
     const credentials = await authenticationClient.getTwoLeggedToken(clientId, clientSecret, [Scopes.ViewablesRead]);
-    const manifest = await modelDerivativeClient.getManifest(credentials.access_token, urn);
+    const manifest = await modelDerivativeClient.getManifest(credentials.access_token, urn, { region });
     const derivatives = [];
     function traverse(derivative) {
         if (derivative.type === 'resource' && derivative.role === 'graphics' && derivative.mime === 'application/autodesk-svf') {

--- a/samples/shared.js
+++ b/samples/shared.js
@@ -13,7 +13,7 @@ async function downloadDerivative(urn, derivativeUrn, clientId, clientSecret) {
     return response.data;
 }
 
-async function getSvfDerivatives(urn, clientId, clientSecret, region) {
+async function getSvfDerivatives(urn, clientId, clientSecret, host, region) {
     const sdkManager = SdkManagerBuilder.create().build();
     const authenticationClient = new AuthenticationClient(sdkManager);
     const modelDerivativeClient = new ModelDerivativeClient(sdkManager);

--- a/src/f2d/downloader.ts
+++ b/src/f2d/downloader.ts
@@ -34,7 +34,7 @@ export class Downloader {
     constructor(protected authenticationProvider: IAuthenticationProvider, host?: string, region?: Region) {
         this.sdkManager = SdkManagerBuilder.create().build();
         this.modelDerivativeClient = new ModelDerivativeClient(this.sdkManager);
-        this.host = 'developer.api.autodesk.com'
+        this.host = host || 'developer.api.autodesk.com'
         this.region = region || 'US';
     }
 

--- a/src/svf/downloader.ts
+++ b/src/svf/downloader.ts
@@ -36,7 +36,7 @@ export class Downloader {
     constructor(protected authenticationProvider: IAuthenticationProvider, host?: string, region?: Region) {
         this.sdkManager = SdkManagerBuilder.create().build();
         this.modelDerivativeClient = new ModelDerivativeClient(this.sdkManager);
-        this.host = 'developer.api.autodesk.com'
+        this.host = host || 'developer.api.autodesk.com'
         this.region = region || 'US';
     }
 

--- a/src/svf/reader.ts
+++ b/src/svf/reader.ts
@@ -4,7 +4,7 @@ import Zip from 'adm-zip';
 import axios from 'axios';
 import { isNullOrUndefined } from 'util';
 import { SdkManagerBuilder } from '@aps_sdk/autodesk-sdkmanager';
-import { ManifestDerivativesChildren, ModelDerivativeClient } from '@aps_sdk/model-derivative';
+import { ManifestDerivativesChildren, ModelDerivativeClient, Region } from '@aps_sdk/model-derivative';
 import { Scopes } from '@aps_sdk/authentication';
 import { PropDbReader } from '../common/propdb-reader';
 import { parseFragments } from './fragments';
@@ -210,12 +210,12 @@ export class Reader {
      * @param {string} region Optional region to be used by all APS calls.
      * @returns {Promise<Reader>} Reader for the provided SVF.
      */
-    static async FromDerivativeService(urn: string, guid: string, authenticationProvider: IAuthenticationProvider, host?: string, region?: string): Promise<Reader> {
+    static async FromDerivativeService(urn: string, guid: string, authenticationProvider: IAuthenticationProvider, host?: string, region?: Region): Promise<Reader> {
         urn = urn.replace(/=/g, '');
         const sdkManager = SdkManagerBuilder.create().build();
         const modelDerivativeClient = new ModelDerivativeClient(sdkManager);
         const accessToken = await authenticationProvider.getToken([Scopes.ViewablesRead]);
-        const manifest = await modelDerivativeClient.getManifest(accessToken, urn);
+        const manifest = await modelDerivativeClient.getManifest(accessToken, urn, { region });
         let foundDerivative: ManifestDerivativesChildren | null = null;
         function findDerivative(derivative: ManifestDerivativesChildren) {
             if (derivative.type === 'resource' && derivative.role === 'graphics' && derivative.guid === guid) {


### PR DESCRIPTION
Addresses #82 

I have made the following updates:

- Adds parsing of `APS_HOST` and `APS_REGION` (under the hood only region one is used, added host so we do not need to change the order of parameters in `SvfReader.FromDerivativeService`)
- Updates `README.md`

I have tested the fix with all the _samples_.

Now, I understand that this fix should have probably been done in the new `aps_sdk/autodesk-sdkmanager` which would make more sense from my point of view to store `region`, `host`, etc in the manager instead of passing it down to specific functions. 
On the other hand, this way we can quickly add support for the region and think about adding it to `autodesk-sdkmanager` once it is stable.

P.S.: I also should have probably refactored `downloader` in `f2d` because it is very close to the `svf` one and moved it to `common` or something along that. Lmk if I should do it. But again, I would like to keep the fix as small as possible. 

Thank you!