### PR TITLE
Adding missing units to the view

### DIFF
--- a/src/svf2/helpers/View.ts
+++ b/src/svf2/helpers/View.ts
@@ -54,6 +54,15 @@ const FragmentTransformsOffsetSchema = z.object({
     z: z.number()
 });
 
+const WorldBoundingBoxSchema = z.object({
+    minXYZ: z.array(z.number()),
+    maxXYZ: z.array(z.number())
+});
+
+const WorldVectorSchema = z.object({
+    XYZ: z.array(z.number())
+});
+
 const ViewSchema = z.object({
     name: z.string(),
     version: z.number(),

--- a/src/svf2/helpers/View.ts
+++ b/src/svf2/helpers/View.ts
@@ -60,7 +60,12 @@ const ViewSchema = z.object({
     manifest: ManifestSchema,
     stats: StatsSchema.optional(),
     georeference: GeoreferenceSchema.optional(),
-    fragmentTransformsOffset: FragmentTransformsOffsetSchema.optional()
+    fragmentTransformsOffset: FragmentTransformsOffsetSchema.optional(),
+    "world bounding box": WorldBoundingBoxSchema.optional(),
+    "world up vector": WorldVectorSchema.optional(),
+    "world front vector": WorldVectorSchema.optional(),
+    "world north vector": WorldVectorSchema.optional(),
+    "distance unit": z.object({ value: z.string() }).optional()
 });
 
 export type View = z.infer<typeof ViewSchema>;


### PR DESCRIPTION
ViewSchema is missing world vectors, bounding box, and units.

Adding them here allows the method getViewMetadata to compute the scale transformations.