### PR TITLE
feat: Add configurable base address support for APS API endpoints

### DIFF
--- a/src/svf/reader.ts
+++ b/src/svf/reader.ts
@@ -12,6 +12,7 @@ import { parseMeshes } from './meshes';
 import * as SVF from './schema';
 import * as IMF from '../common/intermediate-format';
 import { IAuthenticationProvider } from '../common/authentication-provider';
+import { SdkManagerBuilder } from '@aps_sdk/autodesk-sdkmanager';
 
 /**
  * Entire content of SVF and its assets loaded in memory.
@@ -207,9 +208,14 @@ export class Reader {
      * @param {Region} [region] Optional region to be used by all APS calls.
      * @returns {Promise<Reader>} Reader for the provided SVF.
      */
-    static async FromDerivativeService(urn: string, guid: string, authenticationProvider: IAuthenticationProvider, region?: Region): Promise<Reader> {
+    static async FromDerivativeService(urn: string, guid: string, authenticationProvider: IAuthenticationProvider, region?: Region, baseAddress="https://developer.api.autodesk.com" ): Promise<Reader> {
         urn = urn.replace(/=/g, '');
-        const modelDerivativeClient = new ModelDerivativeClient();
+        const sdkManager = SdkManagerBuilder.create().addApsConfiguration({
+            baseAddress: new URL(baseAddress),
+            }).build();
+        const modelDerivativeClient = new ModelDerivativeClient({
+            sdkManager,
+            });
         const accessToken = await authenticationProvider.getToken([Scopes.ViewablesRead]);
         const manifest = await modelDerivativeClient.getManifest(urn, { accessToken, region });
         let foundDerivative: ManifestResources | null = null;


### PR DESCRIPTION
## Description
This PR adds support for configuring the base address when using the Model Derivative service, allowing users to connect to different APS environments (staging, production, or custom endpoints).

## Changes
- Added optional `baseAddress` parameter to `FromDerivativeService` method in `src/svf/reader.ts`
- Integrated `SdkManagerBuilder` from `@aps_sdk/autodesk-sdkmanager` to configure the SDK with custom base address
- Default value is set to `"https://developer.api.autodesk.com"` maintaining backward compatibility

## Usage
```typescript
// Default usage (unchanged - uses default base address)
const reader = await Reader.FromDerivativeService(urn, guid, authProvider, region);

// With custom base address for staging environment
const reader = await Reader.FromDerivativeService(
  urn, 
  guid, 
  authProvider, 
  region,
  "https://staging.api.autodesk.com"
);
```

## Motivation
This change is needed to:
- Support different APS environments (staging, production)
- Enable testing against different API endpoints
- Allow enterprise users to point to their custom APS deployments

## Breaking Changes
None - the change is fully backward compatible. The `baseAddress` parameter is optional with a sensible default.

## Testing
- [x] Tested with default base address
- [x] Tested with custom base address
- [x] Verified backward compatibility

## Checklist
- [x] Code follows the project's style guidelines
- [x] Changes are backward compatible
- [x] TypeScript compilation passes without errors